### PR TITLE
Fixing issue importing rigs using the Exported Rigify option

### DIFF
--- a/import_runtime_mhx2/armature/rigify.py
+++ b/import_runtime_mhx2/armature/rigify.py
@@ -81,8 +81,8 @@ else:
     ]
 
     Parents = {
-        "clavicle.L" : "ORG-chest",
-        "clavicle.R" : "ORG-chest",
+        "clavicle.L" : "ORG-spine.003",
+        "clavicle.R" : "ORG-spine.003",
         "shoulder.L" : "clavicle.L",
         "shoulder.R" : "clavicle.R",
         "ORG-shoulder.L" : "clavicle.L",


### PR DESCRIPTION
The chest bone appears to get renamed to spine.003 and the code is attempting to set clavicle bones as children of chest. Modified these mappings to point to the spine.003 bone.