### PR TITLE
Update license information

### DIFF
--- a/9_export_mhx2/mh2mhx2.py
+++ b/9_export_mhx2/mh2mhx2.py
@@ -470,32 +470,18 @@ def getMaterialName(name, meshname, matname):
 
 '''
 BaseMeshLicense = (
-    ["MakeHuman 3d morphing modelled by Manuel Bastioni"],
-    ["Copyright (C) 2014 Manuel Bastioni (mb@makehuman.org)"],
-    ["homepage http://www.makehuman.org"],
+    ["MakeHuman Base Mesh"],
+    ["Copyright (C) 2020 MakeHuman Community"],
+    ["homepage http://www.makehumancommunity.org"],
     ["basemesh hm08"],
-    ["license AGPL3 (http://www.makehuman.org/doc/node/makehuman_mesh_license.html)"],
-    ["   This file is part of MakeHuman (www.makehuman.org)."],
-    [""],
-    ["   This program is free software: you can redistribute it and/or modify"],
-    ["   it under the terms of the GNU Affero General Public License as"],
-    ["   published by the Free Software Foundation, either version 3 of the"],
-    ["   License, or (at your option) any later version."],
-    [""],
-    ["   This program is distributed in the hope that it will be useful,"],
-    ["   but WITHOUT ANY WARRANTY; without even the implied warranty of"],
-    ["   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the"],
-    ["   GNU Affero General Public License for more details."],
-    [""],
-    ["   You should have received a copy of the GNU Affero General Public License"],
-    ["   along with this program.  If not, see <http://www.gnu.org/licenses/>."],
-)
+    ["license CC0 (https://github.com/makehumancommunity/makehuman/blob/master/LICENSE.md)"],
+    ["   This file is part of MakeHuman (www.makehumancommunity.org)."]
 '''
 
 BaseMeshLicense = OrderedDict([
-    ("author",  "Manuel Bastioni"),
-    ("license", "AGPL3 (http://www.makehuman.org/doc/node/makehuman_mesh_license.html)"),
-    ("homepage", "http://www.makehuman.org/")
+    ("author",  "MakeHuman Community"),
+    ("license", "CC0 (https://github.com/makehumancommunity/makehuman/blob/master/LICENSE.md)"),
+    ("homepage", "http://www.makehumancommunity.org/")
 ])
 
 def addProxyLicense(mhGeo, pxy):
@@ -504,8 +490,8 @@ def addProxyLicense(mhGeo, pxy):
         for key in ["author", "license", "homepage"]:
             mhLicense[key] = getattr(pxy.license, key)
     else:
-        mhLicense["author"] = "MakeHuman Team"
-        mhLicense["license"] = "AGPL3 (see also http://www.makehuman.org/doc/node/external_tools_license.html)"
-        mhLicense["homepage"] = "http://www.makehuman.org/"
+        mhLicense["author"] = "MakeHuman Community"
+        mhLicense["license"] = "CC0 (see also https://github.com/makehumancommunity/makehuman/blob/master/LICENSE.md)"
+        mhLicense["homepage"] = "http://www.makehumancommunity.org/"
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ MHX2 is a format to copy data from MakeHuman to Blender using a JSON file. Becau
 
 Original version is hosted separately at https://bitbucket.org/Diffeomorphic/mhx2-makehuman-exchange. To download the repository as a zip file, go to https://bitbucket.org/Diffeomorphic/mhx2-makehuman-exchange/downloads.
 
+The overall license for MHX2 is GPLv2, but there is an additional license clarification at https://thomasmakehuman.wordpress.com/license-information/
+
 This is a downstream version using python3 with fixes for triangle meshes, meshes with huge numbers of vertices and for the use in blender 2.80
 
 Instructions:

--- a/import_runtime_mhx2/license.txt
+++ b/import_runtime_mhx2/license.txt
@@ -1,3 +1,8 @@
+Note that this license text has additional license clarifications here:
+
+https://thomasmakehuman.wordpress.com/license-information/
+
+
 
 ======================================
 MakeHuman Tools License


### PR DESCRIPTION
As the MakeHuman license has changed, we need to update the information about it in the MHX plugin. Note that this is not a change of the MHX2 license, it is only update information about the license change in MakeHuman.

In addition, a link has been added to the license clarification Thomas has written on his wordpress page.