### PR TITLE
Add explicit type conversion for compatability with Blender 3.1

### DIFF
--- a/import_runtime_mhx2/armature/constraints.py
+++ b/import_runtime_mhx2/armature/constraints.py
@@ -94,7 +94,7 @@ class CIkConstraint(CConstraint):
             (self.angle, self.ptar) = (0, None)
         (self.useLoc, self.useRot, self.useStretch) = data[4]
         if len(data) > 5:
-            self.useTail = data[5]
+            self.useTail = bool(data[5])
         else:
             self.useTail = True
         self.lockLoc = lockLoc


### PR DESCRIPTION
Blender 3.1 updated the built-in Python version to 3.10, which no longer implicitly converts floats to ints. `KinematicConstraint.use_tail` expects either a bool, 1, or 0, but was being assigned a float, meaning it broke with this change.
I have added an explicit conversion to a bool to fix the TypeError being thrown.
Fixes #15.